### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,8 +14,8 @@ Motor	KEYWORD1
 
 setfreq	KEYWORD2
 setmotor	KEYWORD2
-setdelay    KEYWORD2
-step        KEYWORD2
+setdelay	KEYWORD2
+step	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
@@ -28,4 +28,4 @@ _STOP	LITERAL1
 _STANDBY	LITERAL1
 _MOTOR_A	LITERAL1
 _MOTOR_B	LITERAL1
-_PWM    LITERAL1
+_PWM	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords